### PR TITLE
Install guide: Throw whole plugin config in one line

### DIFF
--- a/apps/docs/src/content/docs/guides/install.mdx
+++ b/apps/docs/src/content/docs/guides/install.mdx
@@ -12,7 +12,7 @@ import { PackageManagers } from 'starlight-package-managers'
    <PackageManagers pkg="starlight-theme-template"/>
 
 2. Add the theme to your Starlight config.
-   ```ts title="astro.config.mjs" ins={1,9}
+   ```ts title="astro.config.mjs" ins={1,8}
    import theme from "starlight-theme-template";
 
    export default defineConfig({
@@ -20,9 +20,7 @@ import { PackageManagers } from 'starlight-package-managers'
      integrations: [
        starlight({
          // ...
-         plugins: [
-           theme()
-         ]
+         plugins: [theme()]
        })
      ]
    })

--- a/apps/docs/src/content/docs/guides/install.mdx
+++ b/apps/docs/src/content/docs/guides/install.mdx
@@ -3,27 +3,29 @@ title: Install Theme
 description: Install the template theme for Starlight.
 ---
 
-import { Steps } from '@astrojs/starlight/components';
-import { PackageManagers } from 'starlight-package-managers'
+import { Steps } from "@astrojs/starlight/components";
+import { PackageManagers } from "starlight-package-managers";
 
 <Steps>
 
 1. Install the theme package to your project with your preferred package manager:
-   <PackageManagers pkg="starlight-theme-template"/>
+
+   <PackageManagers pkg="starlight-theme-template" />
 
 2. Add the theme to your Starlight config.
+
    ```ts title="astro.config.mjs" ins={1,8}
    import theme from "starlight-theme-template";
 
    export default defineConfig({
-     // ...
-     integrations: [
-       starlight({
-         // ...
-         plugins: [theme()]
-       })
-     ]
-   })
+   	// ...
+   	integrations: [
+   		starlight({
+   			// ...
+   			plugins: [theme()],
+   		}),
+   	],
+   });
    ```
 
 </Steps>


### PR DESCRIPTION
This is probably very opinionated, but I think that many formating tools will force that the plugin configuration is in one line, which messes up the highlight, like this:

![image](https://github.com/user-attachments/assets/c42500ce-8275-4911-8c6b-79cb29cc0dd1)

If you want, we can resolve it by just providing the config that way by default and adjust the hightlight line  number...
If you don't want to, that's completely fine too. You can also see this as a convenience feedback from me! 